### PR TITLE
Add persistent user memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Gemini Telegram Bot
 
 This project demonstrates a simple Telegram bot built with [aiogram](https://github.com/aiogram/aiogram) and the Gemini API. The bot replies to `/start` and forwards any other text to the Gemini API.
+Conversation history is stored per user in a small SQLite database so the model can maintain context across messages.
 
 
 It calls the **Gemini 2.0 Flash** model for fast responses.

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -2,6 +2,12 @@ from aiogram import Router, types
 from aiogram.filters import CommandStart
 
 
+try:
+    from bot.memory import add_message, clear_history, get_history
+except ImportError:  # pragma: no cover - fallback for `python bot/main.py`
+    from memory import add_message, clear_history, get_history
+
+
 # Import relative to package when run with `python -m bot.main`
 
 try:
@@ -15,6 +21,8 @@ router = Router()
 
 @router.message(CommandStart())
 async def start_handler(message: types.Message) -> None:
+    if message.from_user:
+        await clear_history(message.from_user.id)
     await message.answer("Welcome to the Gemini bot!")
 
 
@@ -22,5 +30,9 @@ async def start_handler(message: types.Message) -> None:
 async def echo_with_gemini(message: types.Message) -> None:
     if not message.text:
         return
-    response = await generate_response(message.text)
+    user_id = message.from_user.id if message.from_user else 0
+    history = await get_history(user_id)
+    response = await generate_response(message.text, history)
     await message.answer(response)
+    await add_message(user_id, "user", message.text)
+    await add_message(user_id, "model", response)

--- a/bot/main.py
+++ b/bot/main.py
@@ -5,6 +5,11 @@ import os
 from aiogram import Bot, Dispatcher
 from dotenv import load_dotenv
 
+try:
+    from bot.memory import init_db
+except ImportError:  # pragma: no cover - fallback for `python bot/main.py`
+    from memory import init_db
+
 
 # Allow running the script directly or as a module
 try:
@@ -25,6 +30,8 @@ async def main() -> None:
     bot = Bot(token)
     dp = Dispatcher()
     dp.include_router(router)
+
+    await init_db()
 
     await dp.start_polling(bot)
 

--- a/bot/memory.py
+++ b/bot/memory.py
@@ -1,0 +1,55 @@
+"""Simple user-specific conversation history stored in SQLite."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import aiosqlite
+
+
+DB_PATH = Path(__file__).with_name("history.db")
+
+_INIT_SQL = (
+    "CREATE TABLE IF NOT EXISTS messages ("
+    "user_id INTEGER NOT NULL,"
+    "role TEXT NOT NULL,"
+    "text TEXT NOT NULL,"
+    "ts DATETIME DEFAULT CURRENT_TIMESTAMP"
+    ")"
+)
+
+
+async def init_db() -> None:
+    """Create database and tables if they do not exist."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(_INIT_SQL)
+        await db.commit()
+
+
+async def add_message(user_id: int, role: str, text: str) -> None:
+    """Persist a single message for the given user."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "INSERT INTO messages (user_id, role, text) VALUES (?, ?, ?)",
+            (user_id, role, text),
+        )
+        await db.commit()
+
+
+async def get_history(user_id: int, limit: int = 20) -> list[tuple[str, str]]:
+    """Return the most recent conversation history for a user."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "SELECT role, text FROM messages WHERE user_id = ? ORDER BY ts ASC LIMIT ?",
+            (user_id, limit),
+        ) as cursor:
+            rows: Iterable[tuple[str, str]] = await cursor.fetchall()
+    return list(rows)
+
+
+async def clear_history(user_id: int) -> None:
+    """Remove stored conversation for the user."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("DELETE FROM messages WHERE user_id = ?", (user_id,))
+        await db.commit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiogram==3.*
 python-dotenv
 httpx
+aiosqlite


### PR DESCRIPTION
## Summary
- maintain a per-user conversation history using SQLite
- extend Gemini calls to include prior messages
- wipe history on `/start`
- initialise the new database on startup
- document the new memory feature

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff419733c8329951bc30ff0c0a008